### PR TITLE
Fix browser tab title

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Example</title>
+    <title>Bucket list</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <!-- Do not add `link` tags unless you know what you are doing -->


### PR DESCRIPTION
Why: browser tab title was "example" from the template.

What: n/a

Editorials: n/a

Testing: will be done with first deployment

Consequences: n/a

Closes #31