### PR TITLE
Remove 'name' and 'organization' from register

### DIFF
--- a/assets/templates/registerForm.handlebars
+++ b/assets/templates/registerForm.handlebars
@@ -8,12 +8,6 @@
       <input type='password'
         name='credentials[password_confirmation]' placeholder='confirm password'>
       <br>
-      <input type='text'
-        name='credentials[name]' placeholder='name (optional)'>
-      <br>
-      <input type='text'
-        name='credentials[organization]' placeholder='organization (optional)'>
-      <br>
       <input id='register-submit' type='submit' name='submit' value='Register'>
       <input id='cancel-request' type='button' value='Cancel'>
   </form>


### PR DESCRIPTION
What:
* Removes name/org fields from register dialog.

Why:
* These fields not used in this app.

Consequences: none

Closes #35