### PR TITLE
Issue#51: fix pagination padding

### DIFF
--- a/DataTables/DataTables-1.10.15/css/custom-dataTables.css
+++ b/DataTables/DataTables-1.10.15/css/custom-dataTables.css
@@ -1,0 +1,21 @@
+/*Custom styles that override DataTables css.
+Most of our css files are stored on a CDN and accessed via a link tag in
+index.html. This custom css stylesheet overrides some of those
+styles that come with DataTables with ones stored in this file and
+accessed via a relative path in the index.html file. */
+
+.dataTables_wrapper .dataTables_paginate .paginate_button {
+  box-sizing: border-box;
+  display: inline-block;
+  min-width: 1.5em;
+
+  padding: 0.1em 1em !important;
+  margin-left: 2px;
+  text-align: center;
+  text-decoration: none !important;
+  cursor: pointer;
+  *cursor: hand;
+  color: #333 !important;
+  border: 1px solid transparent;
+  border-radius: 2px;
+}

--- a/DataTables/DataTables-1.10.15/css/custom-dataTables.css
+++ b/DataTables/DataTables-1.10.15/css/custom-dataTables.css
@@ -8,8 +8,7 @@ accessed via a relative path in the index.html file. */
   box-sizing: border-box;
   display: inline-block;
   min-width: 1.5em;
-
-  padding: 0.1em 1em !important;
+  padding: 0.1em 0.1em !important;
   margin-left: 2px;
   text-align: center;
   text-decoration: none !important;

--- a/DataTables/DataTables-1.10.15/css/jquery.dataTables.css
+++ b/DataTables/DataTables-1.10.15/css/jquery.dataTables.css
@@ -298,7 +298,8 @@ table.dataTable td {
   float: right;
   text-align: right;
   padding-top: 0.25em;
-  background: rgba(191, 63, 63, 0.4);
+  /*below I was testing whether styles got applied to dataTables in DOM*/
+  /*background: rgba(191, 63, 63, 0.4);*/
 }
 .dataTables_wrapper .dataTables_paginate .paginate_button {
   box-sizing: border-box;

--- a/DataTables/DataTables-1.10.15/css/jquery.dataTables.css
+++ b/DataTables/DataTables-1.10.15/css/jquery.dataTables.css
@@ -298,6 +298,7 @@ table.dataTable td {
   float: right;
   text-align: right;
   padding-top: 0.25em;
+  background: rgba(191, 63, 63, 0.4);
 }
 .dataTables_wrapper .dataTables_paginate .paginate_button {
   box-sizing: border-box;

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
       <!-- <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.15/css/jquery.dataTables.css"/> -->
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/buttons/1.3.1/css/buttons.dataTables.css"/>
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/select/1.2.2/css/select.dataTables.css"/>
+      <link rel="stylesheet" type="text/css" href="/DataTables/DataTables-1.10.15/css/custom-dataTables.css"/>
 
     <!-- Do not add `script` tags unless you know what you are doing -->
     <script src="public/vendor.js" type="text/javascript" charset="utf-8" defer></script>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,8 @@
 
     <!-- Do not add `link` tags unless you know what you are doing -->
     <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
-    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.15/css/jquery.dataTables.css"/>
+    <link rel="stylesheet" type="text/css" href="/DataTables/DataTables-1.10.15/css/jquery.dataTables.css"/>
+      <!-- <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.15/css/jquery.dataTables.css"/> -->
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/buttons/1.3.1/css/buttons.dataTables.css"/>
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/select/1.2.2/css/select.dataTables.css"/>
 

--- a/index.html
+++ b/index.html
@@ -6,9 +6,9 @@
 
     <!-- Do not add `link` tags unless you know what you are doing -->
     <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
-    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.15/css/jquery.dataTables.min.css"/>
-    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/buttons/1.3.1/css/buttons.dataTables.min.css"/>
-    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/select/1.2.2/css/select.dataTables.min.css"/>
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.15/css/jquery.dataTables.css"/>
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/buttons/1.3.1/css/buttons.dataTables.css"/>
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/select/1.2.2/css/select.dataTables.css"/>
 
     <!-- Do not add `script` tags unless you know what you are doing -->
     <script src="public/vendor.js" type="text/javascript" charset="utf-8" defer></script>

--- a/index.html
+++ b/index.html
@@ -6,11 +6,11 @@
 
     <!-- Do not add `link` tags unless you know what you are doing -->
     <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
-    <link rel="stylesheet" type="text/css" href="/DataTables/DataTables-1.10.15/css/jquery.dataTables.css"/>
-      <!-- <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.15/css/jquery.dataTables.css"/> -->
+    <!-- <link rel="stylesheet" type="text/css" href="/DataTables/DataTables-1.10.15/css/jquery.dataTables.css"/> -->
+      <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.15/css/jquery.dataTables.css"/>
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/buttons/1.3.1/css/buttons.dataTables.css"/>
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/select/1.2.2/css/select.dataTables.css"/>
-      <link rel="stylesheet" type="text/css" href="/DataTables/DataTables-1.10.15/css/custom-dataTables.css"/>
+    <link rel="stylesheet" type="text/css" href="/DataTables/DataTables-1.10.15/css/custom-dataTables.css"/>
 
     <!-- Do not add `script` tags unless you know what you are doing -->
     <script src="public/vendor.js" type="text/javascript" charset="utf-8" defer></script>


### PR DESCRIPTION
Created custom css file to store overrides to default DataTables css styles. custom-DataTables.css successfully overrides default styles and fixes problem with pagination button padding (buttons had too much padding and were too far apart). 