### PR TITLE
Modify DELETE to specify id of row

### DIFF
--- a/assets/scripts/bl-init-params.js
+++ b/assets/scripts/bl-init-params.js
@@ -29,7 +29,7 @@ const editorConfigurationParameters = function () {
       },
       remove: {
         type: 'DELETE',
-        url: config.apiOrigin + '/bucket',
+        url: config.apiOrigin + '/bucket/_id_',
         dataSrc: 'data',
         headers: {'Authorization': 'Token token=' + store.user.authNToken}
       }


### PR DESCRIPTION
What:
* DataTables generates a long URL for DELETE that it does not
generate for other methods. This exploits that.

Consequences: none on UI

Tests: OK

Closes #70