### PR TITLE
Use editor.close on logout

### DIFF
--- a/assets/scripts/authn-logout-ui.js
+++ b/assets/scripts/authn-logout-ui.js
@@ -31,9 +31,10 @@ const success = function (response) {
   announceUI.clear('all')
   // Display log-in/register buttons.
   $('#authn').html(logInRegisterButtons())
-  $('.DTE_Body').remove()
-  $('.DTE_Header_Content').remove()
-  $('.btn').remove()
+  store.editor.close()
+  // $('.DTE_Body').remove()
+  // $('.DTE_Header_Content').remove()
+  // $('.btn').remove()
   $('#bucket').empty()
 }
 

--- a/assets/scripts/bl-init.js
+++ b/assets/scripts/bl-init.js
@@ -2,6 +2,7 @@
 // Initializes the table space after user logs in
 const blInitParams = require('./bl-init-params')
 const bucketList = require('../templates/bucketList.handlebars')
+const store = require('./store')
 
 require('datatables.net-bs')
 require('datatables.net-buttons')
@@ -11,6 +12,7 @@ require('./dataTables.editor.js')
 const blInit = function () {
   // Instantiate the bucket list editor with editor config object
   const editor = new $.fn.dataTable.Editor(blInitParams.editorConfigurationParameters())
+  store.editor = editor
 
   // load DOM with the initial bucketList with main table parameters
   //  object, passing in the reference to the instantiated editor.


### PR DESCRIPTION
Why: fixes bug that prevented edit/new/delete buttons from
working on re-loggin in.

What: placed editor in store (blInit) so that it could be
used at logout.

Closes #95