### PR TITLE
Close editor when settings-change requested

### DIFF
--- a/assets/scripts/authn-settings-ui.js
+++ b/assets/scripts/authn-settings-ui.js
@@ -25,6 +25,8 @@ const failure = function (response) {
 const onRequest = function () {
   // Clear announcement, response & matrix areas.
   announceUI.clear('all')
+  // Remove any editor window
+  store.editor.close()
   // Display settings change form
   $('#authn').html(changeSettings)
   announceUI.post(msg.userInfo, 'logged-in-user')


### PR DESCRIPTION
What: Force editor window to close when user starts the settings-
change dialog.

Why: lingering editor window is irrelevant to settings change,
and confuses the UI after settings change is abandoned or completed.

Consequences: none

Tests: Fixes bug. Did not do regression testing (as usual).

Closes #99