### PR TITLE
Bugfix: text shows on logout if user does not complete delete action

### DIFF
--- a/assets/scripts/authn-logout-ui.js
+++ b/assets/scripts/authn-logout-ui.js
@@ -16,7 +16,7 @@ const failure = function (response) {
 // Clicked the Log-in button
 const onRequest = function () {
   // Remove the log-out & change-settings buttons
-  announceUI.clear('authn')
+  announceUI.clear('all')
   // Tell user he is being logged out.
   announceUI.post(msg.loggingOut, 'announcement')
   authnAPI.logOut()


### PR DESCRIPTION

Responds to Issue #98

References the 'clear' function in announce-ui.js in authn-logout-ui.js
to be sure all announcement text is cleared upon logout.