### PR TITLE
Fixes Editor Modal via CSS Links

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,10 +7,16 @@
     <!-- Do not add `link` tags unless you know what you are doing -->
     <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
     <!-- <link rel="stylesheet" type="text/css" href="/DataTables/DataTables-1.10.15/css/jquery.dataTables.css"/> -->
-      <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.15/css/jquery.dataTables.css"/>
+    <!-- <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.15/css/jquery.dataTables.css"/> -->
+    <!-- <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/dt-1.10.15/jqc-1.12.4,dt-1.10.15,b-1.3.1,se-1.2.2/datatables.min.css"/> -->
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/buttons/1.3.1/css/buttons.dataTables.css"/>
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/select/1.2.2/css/select.dataTables.css"/>
-    <link rel="stylesheet" type="text/css" href="/DataTables/DataTables-1.10.15/css/custom-dataTables.css"/>
+
+    <link rel="stylesheet" type="text/css" href="DataTables/Editor-1.6.3/css/editor.dataTables.css">
+    <link rel="stylesheet" type="text/css" href="DataTables/Editor-1.6.3/css/editor.bootstrap.css">
+    <link rel="stylesheet" type="text/css" href="DataTables/DataTables-1.10.15/css/dataTables.bootstrap.css">
+    <link rel="stylesheet" type="text/css" href="DataTables/DataTables-1.10.15/css/jquery.dataTables.css">
+    <!-- <link rel="stylesheet" type="text/css" href="/DataTables/DataTables-1.10.15/css/custom-dataTables.css"/> -->
 
     <!-- Do not add `script` tags unless you know what you are doing -->
     <script src="public/vendor.js" type="text/javascript" charset="utf-8" defer></script>


### PR DESCRIPTION
Uses local css files rather than CDN for all CSS except buttons/select

Issue needs 6 CSS files:
Buttons CSS
Select CSS
editor.dataTables.css
editor.bootstrap.css
dataTables.bootstrap.css
jquery.dataTables.css (Necessary)

closes #56