### PR TITLE
Fixes Pagination CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <link rel="stylesheet" type="text/css" href="DataTables/Editor-1.6.3/css/editor.dataTables.css">
     <link rel="stylesheet" type="text/css" href="DataTables/Editor-1.6.3/css/editor.bootstrap.css">
     <link rel="stylesheet" type="text/css" href="DataTables/DataTables-1.10.15/css/dataTables.bootstrap.css">
-    <link rel="stylesheet" type="text/css" href="DataTables/DataTables-1.10.15/css/jquery.dataTables.css">
+    <link rel="stylesheet" type="text/css" href="DataTables/DataTables-1.10.15/css/jquery.dataTables_themeroller.css">
     <!-- <link rel="stylesheet" type="text/css" href="/DataTables/DataTables-1.10.15/css/custom-dataTables.css"/> -->
 
     <!-- Do not add `script` tags unless you know what you are doing -->


### PR DESCRIPTION
Changed CSS links to pull from:
DataTables/DataTables-1.10.15/css/jquery.dataTables_themeroller.css

Instead of:
DataTables/DataTables-1.10.15/css/jquery.dataTables.css

closes #107 references #108