### PR TITLE
Fixes problem where divider below header row disappears

### DIFF
--- a/DataTables/DataTables-1.10.15/css/custom-dataTables.css
+++ b/DataTables/DataTables-1.10.15/css/custom-dataTables.css
@@ -6,56 +6,11 @@ styles that come with DataTables with ones stored in this file and
 accessed via a relative path in the index.html file.
 */
 
+/*Creates override that fixes problem where header row divider disappears
+*/
 
-/*fixes problem with excess padding around pagination controls; overrides style
-from dataTables.jqueryui.class*/
-
-.dataTables_wrapper .dataTables_paginate .paginate_button {
-  box-sizing: border-box;
-  display: inline-block;
-  min-width: 1.5em;
-  padding: 0.1em 0.1em !important;
-  margin-left: 2px;
-  text-align: center;
-  text-decoration: none !important;
-  cursor: pointer;
-  *cursor: hand;
-  color: #333 !important;
-  border: 1px solid transparent;
-  border-radius: 2px;
+table.dataTable thead th,
+table.dataTable thead td {
+  padding: 10px 18px;
+  border-bottom: 1px solid #111 !important;
 }
-
-/*DTE_Body contains DTE_Form_Content, which contains our form. */
-
-.DTE_Body{
-  float:left;
-}
-
-
-.DTE_Form_Content{
-  /*Can uncomment color for debugging purposes*/
-  /*background: CornflowerBlue;*/
-}
-
-/*DTE_Footer contains .btn, which styles our create/edit button. */
-
-.DTE_Footer{
-  /*can uncomment color for debugging purposes*/
-  /*background: red;*/
-  padding: 100px;
-  float: right;
-}
-
-.btn{
-/*May use later*/
-}
-
-/*Allows us to use addClass() and removeClass() jquery methods on add/edit form*/
-
-.hidden {
-  display: none;
-}
-
-/*.DTE_Form_Buttons{
-May use later
-}*/

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <link rel="stylesheet" type="text/css" href="DataTables/Editor-1.6.3/css/editor.bootstrap.css">
     <link rel="stylesheet" type="text/css" href="DataTables/DataTables-1.10.15/css/dataTables.bootstrap.css">
     <link rel="stylesheet" type="text/css" href="DataTables/DataTables-1.10.15/css/jquery.dataTables_themeroller.css">
-    <!-- <link rel="stylesheet" type="text/css" href="/DataTables/DataTables-1.10.15/css/custom-dataTables.css"/> -->
+    <link rel="stylesheet" type="text/css" href="/DataTables/DataTables-1.10.15/css/custom-dataTables.css"/>
 
     <!-- Do not add `script` tags unless you know what you are doing -->
     <script src="public/vendor.js" type="text/javascript" charset="utf-8" defer></script>


### PR DESCRIPTION
Adds a custom CSS override file to override default DataTables css

Closes Issue #108