### PR TITLE
Don’t attempt actions on non-existing editor/table

### DIFF
--- a/assets/scripts/announce-ui.js
+++ b/assets/scripts/announce-ui.js
@@ -37,10 +37,11 @@ const clear = function (loc) {
 
 // Delete table, editor, and empty DOM section
 const clearTableAndEditor = function () {
-  // Close the DataTables editor
-  store.editor.close()
-  // Delete the DataTable instance entirely and remove it from the DOM
-  store.table.destroy({'remove': true})
+  // Close the DataTables editor, if it exists
+  if (store.editor) store.editor.close()
+  // Delete the DataTable instance entirely (if it exists)
+  //  and remove it from the DOM
+  if (store.table) store.table.destroy({'remove': true})
   // Empty that section of the DOM to be sure
   $('#bucket').empty()
 }


### PR DESCRIPTION
What:
* Test that editor & table object exist before attempting
  to delete them.

Why: If user is not logged in, and clicks Register, then
  announceUI.clear will attempt to clear out the table and editor.
  These don’t exist if a log-in never occurred.

Tests:
* Tests OK locally.

Consequences: No other impact

Closes #117