### PR TITLE
Fixes CSS Link Tags Breaking During Deployment

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,17 +6,8 @@
 
     <!-- Do not add `link` tags unless you know what you are doing -->
     <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
-    <!-- <link rel="stylesheet" type="text/css" href="/DataTables/DataTables-1.10.15/css/jquery.dataTables.css"/> -->
-    <!-- <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.15/css/jquery.dataTables.css"/> -->
-    <!-- <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/dt-1.10.15/jqc-1.12.4,dt-1.10.15,b-1.3.1,se-1.2.2/datatables.min.css"/> -->
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/buttons/1.3.1/css/buttons.dataTables.css"/>
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/select/1.2.2/css/select.dataTables.css"/>
-
-    <link rel="stylesheet" type="text/css" href="DataTables/Editor-1.6.3/css/editor.dataTables.css">
-    <link rel="stylesheet" type="text/css" href="DataTables/Editor-1.6.3/css/editor.bootstrap.css">
-    <link rel="stylesheet" type="text/css" href="DataTables/DataTables-1.10.15/css/dataTables.bootstrap.css">
-    <link rel="stylesheet" type="text/css" href="DataTables/DataTables-1.10.15/css/jquery.dataTables_themeroller.css">
-    <link rel="stylesheet" type="text/css" href="DataTables/DataTables-1.10.15/css/custom.dataTables.css">
 
     <!-- Do not add `script` tags unless you know what you are doing -->
     <script src="public/vendor.js" type="text/javascript" charset="utf-8" defer></script>

--- a/index.js
+++ b/index.js
@@ -10,3 +10,8 @@ require('./assets/scripts/index.js')
 
 // styles
 require('./sass/index.scss')
+require('./DataTables/Editor-1.6.3/css/editor.dataTables.css')
+require('./DataTables/Editor-1.6.3/css/editor.bootstrap.css')
+require('./DataTables/DataTables-1.10.15/css/dataTables.bootstrap.css')
+require('./DataTables/DataTables-1.10.15/css/jquery.dataTables_themeroller.css')
+require('./DataTables/DataTables-1.10.15/css/custom.dataTables.css')


### PR DESCRIPTION
Link tags referenced local file paths, which works during development,
but breaks during deployment due to webpack changing the file
structure during its bundling.

Solution is leveraging css-loader plugin to require the css files
rather than using link tags in the html.

CSS file paths are removed from the HTML and replaced in require
statements in the root index.js

Removes extraneous link/script comments in HTML Head

references #118 #116