### PR TITLE
Capture log-in failure on bad password

### DIFF
--- a/assets/scripts/authn-login-ui.js
+++ b/assets/scripts/authn-login-ui.js
@@ -16,8 +16,10 @@ const loginAPICall = function (credentials) {
 }
 
 const failure = function (response) {
+  console.log('Login failure: ', response)
   // if statusText = 'Unauthorized', inform user of bad email/password.
   if (response.statusText.includes('Unauthorized') ||
+      response.responseText.includess('Not Authorized') ||
       response.statusText.includes('Not Found')) {
     announceUI.post(msg.badEmailPassword, 'announcement')
   } else {


### PR DESCRIPTION
What: Servers generate a variety of response messages on bad
password or unknown user names. One was missing from our repetoire
that occurs when a valid username is supplied but the password
is incorrect.

Tests: OK

Consequences: none

Closes #125